### PR TITLE
Refactor Banner Date Columns  And Refactor Items Create Function

### DIFF
--- a/prisma/migrations/20241029180446_start_date_end_date/migration.sql
+++ b/prisma/migrations/20241029180446_start_date_end_date/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "banners" ALTER COLUMN "start_date" SET DATA TYPE DATE,
+ALTER COLUMN "end_date" SET DATA TYPE DATE;

--- a/prisma/migrations/20241029183101_rename_banner_in_items_table/migration.sql
+++ b/prisma/migrations/20241029183101_rename_banner_in_items_table/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `is_panner` on the `items` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "items" DROP COLUMN "is_panner",
+ADD COLUMN     "is_banner" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,7 +95,7 @@ model Item {
   country_id  Int // Reference to the country where the item is located
   user_id     Int // Reference to the user
   user        User          @relation("UserItems", fields: [user_id], references: [id]) // Relation to the User model
-  is_panner   Boolean       @default(false) // Indicates if the item is pinned or featured for visibility
+  is_banner   Boolean       @default(false) // Indicates if the item is pinned or featured for visibility
   itemImages  ItemImage[] // Relationship to itemImage join table, allowing for flexible user-image associations
   ActivityLog ActivityLog[] @relation("ItemsActivityLogs") // Relationship to ActivityLog join table, allowing for tracking item-related activities
   Banner      Banner[]
@@ -148,8 +148,8 @@ model Banner {
   item_id    Int // Foreign key referencing the associated Item
   item       Item      @relation(fields: [item_id], references: [id]) // Relation to the Item model
   is_active  Boolean   @default(true) // Indicates whether the banner is currently active
-  start_date DateTime // Start date for the banner display
-  end_date   DateTime // End date for the banner display
+  start_date DateTime  @db.Date // Start date for the banner display
+  end_date   DateTime  @db.Date // End date for the banner display
   created_at DateTime  @default(now()) // Timestamp for when the banner was created
   updated_at DateTime? @default(now()) @updatedAt // Timestamp for the last update to the banner
   deleted_at DateTime? // Optional field for soft delete

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = env("DATABASE_URL_PRD")
 }
 
 enum UserRoles {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,10 @@ import { AuthModule } from './auth/auth.module';
 import { CountriesModule } from './countries/countries.module';
 import { CitiesModule } from './cities/cities.module';
 import { ItemsModule } from './items/items.module';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
-  imports: [UsersModule, PrismaModule, AuthModule, CountriesModule, CitiesModule, ItemsModule],
+  imports: [UsersModule, PrismaModule, AuthModule, CountriesModule, CitiesModule, ItemsModule, CategoriesModule],
   controllers: [],
   providers: [],
 })

--- a/src/categories/categories.controller.spec.ts
+++ b/src/categories/categories.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesController } from './categories.controller';
+
+describe('CategoriesController', () => {
+  let controller: CategoriesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoriesController],
+    }).compile();
+
+    controller = module.get<CategoriesController>(CategoriesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -1,0 +1,46 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, Query } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { CreateCategoryDto } from './create-category.dto';
+
+@Controller('api/categories')
+export class CategoriesController {
+  constructor(private readonly _categoriesService: CategoriesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get all categories' })
+  @ApiResponse({ status: 200, description: 'List of categories.' })
+  async findAll(@Query('limit') limit: number = 5000, @Query('offset') offset: number = 0) {
+    return this._categoriesService.findAll(limit, offset);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a category by ID' })
+  @ApiResponse({ status: 200, description: 'Category found.' })
+  @ApiResponse({ status: 404, description: 'Category not found.' })
+  @Get(':id')
+  async findOne(@Param('id') id: number) {
+    return this._categoriesService.findOne(id);
+  }
+
+  @ApiOperation({ summary: 'Create a new category' })
+  @ApiResponse({ status: 201, description: 'Category created.' })
+  @Post()
+  async create(@Body() createCategoryDto: CreateCategoryDto) {
+    return this._categoriesService.create(createCategoryDto);
+  }
+
+  @ApiOperation({ summary: 'Update a category by ID' })
+  @ApiResponse({ status: 200, description: 'Category updated.' })
+  @Put(':id')
+  async update(@Param('id') id: number, @Body() updateCategoryDto: CreateCategoryDto) {
+    return this._categoriesService.update(id, updateCategoryDto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a category by ID' })
+  @ApiResponse({ status: 204, description: 'Category deleted.' })
+  async remove(@Param('id') id: number) {
+    return this._categoriesService.remove(id);
+  }
+}

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CategoriesController } from './categories.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [CategoriesService],
+  controllers: [CategoriesController]
+})
+export class CategoriesModule {}

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesService } from './categories.service';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoriesService],
+    }).compile();
+
+    service = module.get<CategoriesService>(CategoriesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,0 +1,122 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ResponseUtil } from 'src/common/response.util';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateCategoryDto } from './create-category.dto';
+
+@Injectable()
+export class CategoriesService {
+  constructor(private readonly _prismaService: PrismaService) {}
+
+  private readonly logger = new Logger(CategoriesService.name); // Initializes logger with the class name
+
+  async findAll(limit?: number, offset?: number): Promise<unknown> {
+    try {
+      limit = Number(limit) || 10;
+      offset = Number(offset) || 0;
+      const [categories, total] = await Promise.all([
+        this._prismaService.category.findMany({
+          where: { deleted_at: null, parent_id: null },
+          take: limit,
+          skip: offset,
+          select: {
+            id: true,
+            name_ar: true,
+            name_en: true,
+            description_ar: true,
+            description_en: true,
+            image_url: true,
+            children: {
+              where: { deleted_at: null },
+              select: {
+                id: true,
+                name_ar: true,
+                name_en: true,
+                description_ar: true,
+                description_en: true,
+                image_url: true,
+              },
+            },
+          },
+          orderBy: {
+            id: 'desc',
+          },
+        }),
+        this._prismaService.category.count({
+          where: { deleted_at: null },
+        }),
+      ]);
+
+      this.logger.verbose(`Successfully Retrieved ${categories.length} Categories`);
+      return ResponseUtil.success('Find All Categories', { categories, total });
+    } catch (error) {
+      this.logger.error(`Error In Find All Categories: ${error.message}`, error.stack);
+      return ResponseUtil.error('An error occurred while searching for Categories', 'FIND_ALL_FAILED', error?.message);
+    }
+  }
+
+  async findOne(id: number): Promise<unknown> {
+    try {
+      const category = await this._prismaService.category.findUnique({
+        where: { id: Number(id) },
+      });
+      return ResponseUtil.success('Find Category By ID', category);
+    } catch (error) {
+      this.logger.error(`Error In Find Category By ID: ${error.message}`, error.stack);
+      return ResponseUtil.error('An error occurred while searching for category', 'FIND_ONE_FAILED', error?.message);
+    }
+  }
+
+  async create(data: CreateCategoryDto): Promise<unknown> {
+    try {
+      const category = await this._prismaService.category.create({
+        data: {
+          name_ar: data.name_ar,
+          name_en: data.name_en,
+          description_ar: data.description_ar,
+          description_en: data.description_en,
+          image_url: data.image_url,
+          parent_id: data.parent_id,
+        },
+      });
+      return ResponseUtil.success('Category Created', category);
+    } catch (error) {
+      this.logger.error(`Error In Create Category: ${error.message}`, error.stack);
+      return ResponseUtil.error('An error occurred while creating category', 'CREATE_FAILED', error?.message);
+    }
+  }
+
+  async update(id: number, data: CreateCategoryDto): Promise<unknown> {
+    try {
+      const category = await this._prismaService.category.update({
+        where: { id: Number(id) },
+        data: {
+          name_ar: data.name_ar,
+          name_en: data.name_en,
+          description_ar: data.description_ar,
+          description_en: data.description_en,
+          image_url: data.image_url,
+          parent_id: data.parent_id,
+        },
+      });
+      return ResponseUtil.success('Category Updated', category);
+    } catch (error) {
+      this.logger.error(`Error In Update Category: ${error.message}`, error.stack);
+      return ResponseUtil.error('An error occurred while updating category', 'UPDATE_FAILED', error?.message);
+    }
+  }
+
+  async remove(id: number): Promise<unknown> {
+    try {
+      const category = await this._prismaService.category.update({
+        where: { id: Number(id) },
+        data: {
+          deleted_at: new Date(),
+        },
+      });
+      return ResponseUtil.success('Category Deleted', category);
+    } catch (error) {
+      this.logger.error(`Error In Delete Category: ${error.message}`, error.stack);
+      return ResponseUtil.error('An error occurred while deleting category', 'DELETE_FAILED', error?.message);
+    }
+  }
+}

--- a/src/categories/create-category.dto.ts
+++ b/src/categories/create-category.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsInt, IsOptional } from 'class-validator';
+
+export class CreateCategoryDto {
+  @IsString()
+  name_ar: string;
+
+  @IsString()
+  name_en: string;
+
+  @IsString()
+  description_ar?: string;
+
+  @IsString()
+  description_en?: string;
+
+  @IsString()
+  @IsOptional()
+  image_url?: string;
+
+  @IsInt()
+  @IsOptional()
+  parent_id?: number;
+}

--- a/src/items/create-item.dto.ts
+++ b/src/items/create-item.dto.ts
@@ -34,7 +34,7 @@ export class CreateItemDto {
 
   @IsBoolean()
   @IsOptional()
-  is_panner?: boolean;
+  is_banner?: boolean;
 
   @IsDate()
   @Type(() => Date)
@@ -54,5 +54,15 @@ export class CreateItemDto {
   category_id: number;
 
   @IsArray()
-  image_urls?: string[]; // Array of image URLs to associate with the item
+  image_urls?: string[];
+
+  @IsDate()
+  @Type(() => Date)
+  @IsOptional()
+  start_date?: Date;
+
+  @IsDate()
+  @Type(() => Date)
+  @IsOptional()
+  end_date?: Date;
 }

--- a/src/items/items.service.ts
+++ b/src/items/items.service.ts
@@ -68,6 +68,11 @@ export class ItemsService {
 
   async create(data: CreateItemDto): Promise<unknown> {
     try {
+
+
+   
+
+
       const item = await this._prismaService.item.create({
         data: {
           title: data.title,
@@ -77,7 +82,7 @@ export class ItemsService {
           condition: data.condition,
           trade_value: data.trade_value,
           user_id: data.user_id,
-          is_panner: data.is_panner,
+          is_banner: data.is_banner,
           category_id: data.category_id,
         },
       });
@@ -92,19 +97,29 @@ export class ItemsService {
         });
       }
 
-      if (data.is_panner) {
-        const today = new Date();
-        const endDate = new Date(today);
-        endDate.setDate(today.getDate() + 7); // Set end_date to a week from today
+      if (data.is_banner) {
+        // Convert start_date to Date object if it's a string, or default to today's date
+        const startDate = data.start_date ? new Date(data.start_date) : new Date();
+        const [startYear, startMonth, startDay] = startDate.toISOString().split('T')[0].split('-');
+        const formattedStartDate = new Date(`${startYear}-${startMonth}-${startDay}`);
+      
+        // Convert end_date to Date object if it's a string, or default to 7 days after start date
+        const endDate = data.end_date ? new Date(data.end_date) : new Date(formattedStartDate.getTime() + 7 * 24 * 60 * 60 * 1000);
+        const [endYear, endMonth, endDay] = endDate.toISOString().split('T')[0].split('-');
+        const formattedEndDate = new Date(`${endYear}-${endMonth}-${endDay}`);
+      
+        // Create the banner
         await this._prismaService.banner.create({
           data: {
             item_id: item.id,
             is_active: true,
-            start_date: today,
-            end_date: endDate,
+            start_date: formattedStartDate,
+            end_date: formattedEndDate,
           },
         });
       }
+      
+      
       return ResponseUtil.success('Item Created', item);
     } catch (error) {
       this.logger.error(`Error In Create Item: ${error.message}`, error.stack);
@@ -124,7 +139,7 @@ export class ItemsService {
           condition: data.condition,
           trade_value: data.trade_value,
           user_id: data.user_id,
-          is_panner: data.is_panner,
+          is_banner: data.is_banner,
           category_id: data.category_id,
         },
       });
@@ -178,7 +193,6 @@ export class ItemsService {
     return { message: 'Batch insertion completed' };
   }
 
-
   async createMultiple22(data: CreateItemDto): Promise<unknown> {
     const arabicItems = [
       { title: 'كتاب', description: 'كتاب يحتوي على معلومات ومواضيع مختلفة.' },
@@ -222,7 +236,6 @@ export class ItemsService {
 
     return { message: 'Batch insertion completed' };
   }
-
 
   async createMultiple2(data: CreateItemDto): Promise<unknown> {
     const arabicItems = [
@@ -462,108 +475,108 @@ export class ItemsService {
     ];
     const arabicItems2 = [
       ...arabicItems,
-      { title: "خريطة قديمة", description: "خريطة توضح الطرقات والممرات في البرية." },
-      { title: "مدفع بخاري", description: "مدفع يستخدم للقضاء على المخاطر في المناطق النائية." },
-      { title: "عربة الغجر", description: "عربة صغيرة مخصصة للرحالة والبدو." },
-      { title: "حصان عربي", description: "حصان سريع ومتأقلم مع الصحراء." },
-      { title: "خيمة مسافرين", description: "خيمة خفيفة الوزن وسهلة للنقل." },
-      { title: "فأس", description: "أداة لحفر الأرض أو قطع الأشجار." },
-      { title: "قوس وسهم", description: "أداة للصيد وصنع الأسلحة." },
-      { title: "غذاء مجفف", description: "طعام محفوظ لرحلات الطوال." },
-      { title: "منظار", description: "عدسة مكبرة لمشاهدة مسافات بعيدة." },
-      { title: "حبل متين", description: "حبل يستخدم لأغراض متعددة في المعسكرات." },
-      { title: "علبة إسعافات أولية", description: "مجموعة أدوات لعلاج الإصابات." },
-      { title: "موقد محمول", description: "موقد يستخدم للطهي أثناء التنقل." },
-      { title: "سلة تضم أدوات الصيد", description: "سلة تحتوي على أدوات الصيد الأساسية." },
-      { title: "دليل النجوم", description: "كتاب يعلم كيفية الملاحة باستخدام النجوم." },
-      { title: "حقيبة ظهر", description: "حقيبة لحمل المستلزمات أثناء الرحلات." },
-      { title: "شمسية حماية", description: "أداة لحماية من الشمس أثناء التنقل." },
-      { title: "سترة واقية", description: "سترة توفر الحماية الشخصي." },
-      { title: "كاميرا قديمة", description: "كاميرا لتوثيق المغامرات والتجارب." },
-      { title: "صيد السمك", description: "أدوات لصيد الأسماك من الأنهار أو البحيرات." },
-      { title: "مفتاح أوروبي", description: "أداة تفتح الأبواب المغلقة." },
-      { title: "طاولة قابلة للطي", description: "طاولة خفيفة ومحمولة." },
-      { title: "مقعد خشبي", description: "مقعد للاسترخاء بالقرب من النار." },
-      { title: "علبة أدوات النجارة", description: "أدوات لإنشاء الإصلاحات اللازمة." },
-      { title: "حيوان أليف", description: "رفيق في الرحلات عبر البرية." },
-      { title: "صندوق الكنز", description: "صندوق لحفظ الأشياء الثمينة." },
-      { title: "سفينة شراعية", description: "سفينة تستخدم للتنقل عبر المياه." },
-      { title: "قناع تنفس", description: "قناع لحماية الوجه أثناء العواصف الرملية." },
-      { title: "أضواء ساطعة", description: "أداة لإضاءة الليل." },
-      { title: "صخرة حادة", description: "صخرة تستخدم كأداة قطع." },
-      { title: "قنينة المياه", description: "لحفظ المياه في الرحلات." },
-      { title: "تلسكوب", description: "لرؤية الأجرام السماوية." },
-      { title: "دليل الحيوانات", description: "كتاب يصف أنواع الحيوانات في المنطقة." },
-      { title: "حافظة الطعام", description: "لحفظ الطعام الطازج أثناء التنقل." },
-      { title: "حقيبة أدوات", description: "حقيبة مخصصة لحمل الأدوات اللازمة." },
-      { title: "نقود معدنية", description: "للشراء في المعسكرات." },
-      { title: "جهاز ملاحة", description: "جهاز يساعد في تحديد الاتجاهات." },
-      { title: "ماكينة حلاقة", description: "للحفاظ على مظهر جيد في الرحلات." },
-      { title: "دلو", description: "حاوية لجمع المياه أو نقل الأشياء." },
-      { title: "شجرة خشبية", description: "شفافة تستخدم في بناء الملاجئ." },
-      { title: "مصباح يدوي", description: "للإضاءة في الأماكن المظلمة." },
-      { title: "جوارب صوفية", description: "للحفاظ على القدمين دافئة." },
-      { title: "خريطة مذهلة", description: "خريطة للجغرافيّة المحلية." },
-      { title: "شجرة فواكه", description: "مصدر طبيعي للغذاء." },
-      { title: "مفك براغي", description: "مفتاح لإصلاح المعدات." },
-      { title: "قتال بقبضات", description: "لزيادة المهارات القتالية." },
-      { title: "قارب", description: "للنقل عبر الأنهار والبحيرات." },
-      { title: "قفازات جلدية", description: "لحماية اليدين أثناء العمل الشاق." },
-      { title: "سماد طبيعي", description: "للتربة وتحسين المزروعات." },
-      { title: "منارة", description: "دليل لمساعدة السفن في المياه." },
-      { title: "سفينة تجارية", description: "للنقل التجاري عبر المحيطات." },
-      { title: "بندقية قنص", description: "لصيد الحيوانات الكبيرة." },
-      { title: "سيارة رباعية الدفع", description: "للسير عبر التضاريس الوعرة." },
-      { title: "دلاء رملية", description: "للمشي على الشاطئ." },
-      { title: "معدات طهي", description: "لتحضير الطعام في البرية." },
-      { title: "درع حماية", description: "لحماية جسمك من الأذى." },
-      { title: "جراب سلاح", description: "لحمل السلاح بأمان." },
-      { title: "كشافات النجاح", description: "الأدوات المستخدمة في صيد الأسماك." },
-      { title: "بذور نباتات", description: "لزراعة المحاصيل في المواسم." },
-      { title: "أدوات خاصة لاستكشاف", description: "أدوات تحتاجها لاستكشاف المناطق الجديدة." },
-      { title: "خزينة", description: "لحفظ الأموال والممتلكات الثمينة." },
-      { title: "دليل الطرق", description: "كتاب يحتوي على معلومات عن طرق السير." },
-      { title: "لوحة رسم", description: "لوحة تُستخدم للرسم في الطبيعة." },
-      { title: "كتب تحتوي على نصائح البقاء", description: "كتب تُساعد في كيفية البقاء على قيد الحياة." },
-      { title: "مرافق طبي", description: "للرعاية الطبية في الرحلات." },
-      { title: "فطائر محلية", description: "طعامة تُحضر في المعسكرات." },
-      { title: "كنز دفين", description: "كنز مفقود يتطلب البحث." },
-  ];
-  // console.log({ arabicItems });
-  // console.log({ arabicItems2 });
-  
-  // Example of how you might use this array in your code
+      { title: 'خريطة قديمة', description: 'خريطة توضح الطرقات والممرات في البرية.' },
+      { title: 'مدفع بخاري', description: 'مدفع يستخدم للقضاء على المخاطر في المناطق النائية.' },
+      { title: 'عربة الغجر', description: 'عربة صغيرة مخصصة للرحالة والبدو.' },
+      { title: 'حصان عربي', description: 'حصان سريع ومتأقلم مع الصحراء.' },
+      { title: 'خيمة مسافرين', description: 'خيمة خفيفة الوزن وسهلة للنقل.' },
+      { title: 'فأس', description: 'أداة لحفر الأرض أو قطع الأشجار.' },
+      { title: 'قوس وسهم', description: 'أداة للصيد وصنع الأسلحة.' },
+      { title: 'غذاء مجفف', description: 'طعام محفوظ لرحلات الطوال.' },
+      { title: 'منظار', description: 'عدسة مكبرة لمشاهدة مسافات بعيدة.' },
+      { title: 'حبل متين', description: 'حبل يستخدم لأغراض متعددة في المعسكرات.' },
+      { title: 'علبة إسعافات أولية', description: 'مجموعة أدوات لعلاج الإصابات.' },
+      { title: 'موقد محمول', description: 'موقد يستخدم للطهي أثناء التنقل.' },
+      { title: 'سلة تضم أدوات الصيد', description: 'سلة تحتوي على أدوات الصيد الأساسية.' },
+      { title: 'دليل النجوم', description: 'كتاب يعلم كيفية الملاحة باستخدام النجوم.' },
+      { title: 'حقيبة ظهر', description: 'حقيبة لحمل المستلزمات أثناء الرحلات.' },
+      { title: 'شمسية حماية', description: 'أداة لحماية من الشمس أثناء التنقل.' },
+      { title: 'سترة واقية', description: 'سترة توفر الحماية الشخصي.' },
+      { title: 'كاميرا قديمة', description: 'كاميرا لتوثيق المغامرات والتجارب.' },
+      { title: 'صيد السمك', description: 'أدوات لصيد الأسماك من الأنهار أو البحيرات.' },
+      { title: 'مفتاح أوروبي', description: 'أداة تفتح الأبواب المغلقة.' },
+      { title: 'طاولة قابلة للطي', description: 'طاولة خفيفة ومحمولة.' },
+      { title: 'مقعد خشبي', description: 'مقعد للاسترخاء بالقرب من النار.' },
+      { title: 'علبة أدوات النجارة', description: 'أدوات لإنشاء الإصلاحات اللازمة.' },
+      { title: 'حيوان أليف', description: 'رفيق في الرحلات عبر البرية.' },
+      { title: 'صندوق الكنز', description: 'صندوق لحفظ الأشياء الثمينة.' },
+      { title: 'سفينة شراعية', description: 'سفينة تستخدم للتنقل عبر المياه.' },
+      { title: 'قناع تنفس', description: 'قناع لحماية الوجه أثناء العواصف الرملية.' },
+      { title: 'أضواء ساطعة', description: 'أداة لإضاءة الليل.' },
+      { title: 'صخرة حادة', description: 'صخرة تستخدم كأداة قطع.' },
+      { title: 'قنينة المياه', description: 'لحفظ المياه في الرحلات.' },
+      { title: 'تلسكوب', description: 'لرؤية الأجرام السماوية.' },
+      { title: 'دليل الحيوانات', description: 'كتاب يصف أنواع الحيوانات في المنطقة.' },
+      { title: 'حافظة الطعام', description: 'لحفظ الطعام الطازج أثناء التنقل.' },
+      { title: 'حقيبة أدوات', description: 'حقيبة مخصصة لحمل الأدوات اللازمة.' },
+      { title: 'نقود معدنية', description: 'للشراء في المعسكرات.' },
+      { title: 'جهاز ملاحة', description: 'جهاز يساعد في تحديد الاتجاهات.' },
+      { title: 'ماكينة حلاقة', description: 'للحفاظ على مظهر جيد في الرحلات.' },
+      { title: 'دلو', description: 'حاوية لجمع المياه أو نقل الأشياء.' },
+      { title: 'شجرة خشبية', description: 'شفافة تستخدم في بناء الملاجئ.' },
+      { title: 'مصباح يدوي', description: 'للإضاءة في الأماكن المظلمة.' },
+      { title: 'جوارب صوفية', description: 'للحفاظ على القدمين دافئة.' },
+      { title: 'خريطة مذهلة', description: 'خريطة للجغرافيّة المحلية.' },
+      { title: 'شجرة فواكه', description: 'مصدر طبيعي للغذاء.' },
+      { title: 'مفك براغي', description: 'مفتاح لإصلاح المعدات.' },
+      { title: 'قتال بقبضات', description: 'لزيادة المهارات القتالية.' },
+      { title: 'قارب', description: 'للنقل عبر الأنهار والبحيرات.' },
+      { title: 'قفازات جلدية', description: 'لحماية اليدين أثناء العمل الشاق.' },
+      { title: 'سماد طبيعي', description: 'للتربة وتحسين المزروعات.' },
+      { title: 'منارة', description: 'دليل لمساعدة السفن في المياه.' },
+      { title: 'سفينة تجارية', description: 'للنقل التجاري عبر المحيطات.' },
+      { title: 'بندقية قنص', description: 'لصيد الحيوانات الكبيرة.' },
+      { title: 'سيارة رباعية الدفع', description: 'للسير عبر التضاريس الوعرة.' },
+      { title: 'دلاء رملية', description: 'للمشي على الشاطئ.' },
+      { title: 'معدات طهي', description: 'لتحضير الطعام في البرية.' },
+      { title: 'درع حماية', description: 'لحماية جسمك من الأذى.' },
+      { title: 'جراب سلاح', description: 'لحمل السلاح بأمان.' },
+      { title: 'كشافات النجاح', description: 'الأدوات المستخدمة في صيد الأسماك.' },
+      { title: 'بذور نباتات', description: 'لزراعة المحاصيل في المواسم.' },
+      { title: 'أدوات خاصة لاستكشاف', description: 'أدوات تحتاجها لاستكشاف المناطق الجديدة.' },
+      { title: 'خزينة', description: 'لحفظ الأموال والممتلكات الثمينة.' },
+      { title: 'دليل الطرق', description: 'كتاب يحتوي على معلومات عن طرق السير.' },
+      { title: 'لوحة رسم', description: 'لوحة تُستخدم للرسم في الطبيعة.' },
+      { title: 'كتب تحتوي على نصائح البقاء', description: 'كتب تُساعد في كيفية البقاء على قيد الحياة.' },
+      { title: 'مرافق طبي', description: 'للرعاية الطبية في الرحلات.' },
+      { title: 'فطائر محلية', description: 'طعامة تُحضر في المعسكرات.' },
+      { title: 'كنز دفين', description: 'كنز مفقود يتطلب البحث.' },
+    ];
+    // console.log({ arabicItems });
+    // console.log({ arabicItems2 });
+
+    // Example of how you might use this array in your code
     const batchSize = 1000; // Define the batch size
     const items = [];
     const totalItems = 100; // Total items to insert
 
     // Create all 500,000 item records in memory
     for (let index = 0; index < totalItems; index++) {
-        // Get a random index for the arabicItems array
-        const randomIndex = Math.floor(Math.random() * arabicItems2.length);
-        const { title, description } = arabicItems2[randomIndex]; // Get random item from the array
+      // Get a random index for the arabicItems array
+      const randomIndex = Math.floor(Math.random() * arabicItems2.length);
+      const { title, description } = arabicItems2[randomIndex]; // Get random item from the array
 
-        items.push({
-            ...data,
-            title: title, // Use the Arabic name as title
-            description: description, // Use the Arabic description
-        });
+      items.push({
+        ...data,
+        title: title, // Use the Arabic name as title
+        description: description, // Use the Arabic description
+      });
     }
 
     // Insert items in batches
     for (let i = 0; i < items.length; i += batchSize) {
-        const batch = items.slice(i, i + batchSize); // Get a batch of items
+      const batch = items.slice(i, i + batchSize); // Get a batch of items
 
-        await this._prismaService.item.createMany({
-            data: batch,
-            skipDuplicates: true, // Optional: Skip records with duplicate unique fields
-        });
+      await this._prismaService.item.createMany({
+        data: batch,
+        skipDuplicates: true, // Optional: Skip records with duplicate unique fields
+      });
 
-        console.log(`Inserted batch ${i / batchSize + 1}`);
+      console.log(`Inserted batch ${i / batchSize + 1}`);
     }
 
     return { message: 'Batch insertion completed' };
-}
+  }
 
   // Search for items
   async search(query: string): Promise<unknown> {
@@ -575,14 +588,14 @@ export class ItemsService {
       const itemsPromise = this._prismaService.item.findMany({
         take: limit,
         skip: offset,
-        select:{
-          id:true,
-          title:true,
-          description:true,
-          itemImages:{
-            select:{
-              image_url:true,
-            }
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          itemImages: {
+            select: {
+              image_url: true,
+            },
           },
         },
         where: {

--- a/src/items/items.service.ts
+++ b/src/items/items.service.ts
@@ -68,11 +68,6 @@ export class ItemsService {
 
   async create(data: CreateItemDto): Promise<unknown> {
     try {
-
-
-   
-
-
       const item = await this._prismaService.item.create({
         data: {
           title: data.title,


### PR DESCRIPTION

-   **Migration Script Updates:**
    
    -   Alter `start_date` and `end_date` columns in the `banners` table to use `DATE` type instead of `DATETIME`.
    -   Rename `is_panner` to `is_banner` in the `items` table, replacing it with a new `is_banner` column set to default `false`.
-   **DTO and Schema Updates:**
    
    -   Update `CreateItemDto` to replace `is_panner` with `is_banner`.
    -   Modify `schema.prisma` to rename `is_panner` to `is_banner` in the `Item` model, and set `@db.Date` for `start_date` and `end_date` fields in the `Banner` model.
    
-   **Enhanced `Items` Create Function**:
    -   Update `create` function to accept and process `banner` data.
    -   Automatically generate and save associated banner details, including `start_date`, `end_date`, and `is_banner` status.